### PR TITLE
Allow to install and run Kodi Logfile Uploader from the settings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -261,3 +261,11 @@ msgstr ""
 msgctxt "#30882"
 msgid "Enable debug logging"
 msgstr ""
+
+msgctxt "#30883"
+msgid "Install Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30884"
+msgid "Open Kodi Logfile Uploader…"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -263,3 +263,11 @@ msgstr "Logboek"
 msgctxt "#30882"
 msgid "Enable debug logging"
 msgstr "Activeer debug logging"
+
+msgctxt "#30883"
+msgid "Install Kodi Logfile Uploader…"
+msgstr "Installeer Kodi Logfile Uploader…"
+
+msgctxt "#30884"
+msgid "Open Kodi Logfile Uploader…"
+msgstr "Open Kodi Logfile Uploader…"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,5 +24,7 @@
     <category label="30880"> <!-- Expert -->
         <setting label="30881" type="lsep"/> <!-- Logging -->
         <setting label="30882" type="bool" id="debug_logging" default="false"/>
+        <setting label="30883" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
+        <setting label="30884" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
     </category>
 </settings>


### PR DESCRIPTION
This adds an item to the Expert settings to allow users to view or upload their kodi log using the **Kodi Logfile Uploader** Add-on. This makes it easier to troubleshoot issues on systems where the log is difficult to access, like the new Google Chromecast (Android TV).

It seems that on LibreElec this feature is already integrated in the LibreElec settings.