### PR TITLE
Depend on inputstreamhelper to make sure widevine is installed

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
+        <import addon="script.module.inputstreamhelper" version="0.5.1"/>
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
         <import addon="script.module.requests" version="2.22.0"/>
         <import addon="script.module.routing" version="0.2.0"/>

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -221,8 +221,12 @@ def play(stream, license_key=None, title=None, art_dict=None, info_dict=None, pr
     play_item.setMimeType('application/dash+xml')
     play_item.setContentLookup(False)
 
-    play_item.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
-    play_item.setProperty('inputstream.adaptive.license_key', license_key)
+    if license_key is not None:
+        import inputstreamhelper
+        is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+        if is_helper.check_inputstream():
+            play_item.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
+            play_item.setProperty('inputstream.adaptive.license_key', license_key)
 
     xbmcplugin.setResolvedUrl(routing.handle, True, listitem=play_item)
 


### PR DESCRIPTION
This adds inputstreamhelper and fixes https://github.com/add-ons/plugin.video.tvvlaanderen/issues/19