### PR TITLE
Fix EPG on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
-        exclude:
-          # The bundled version of Python in the windows build is 3.8
+        include:
+          # Kodi Leia on Windows uses a bundled Python 2.7
           - os: windows-latest
-            python-version: 3.6
+            python-version: 2.7
+          # Kodi Matrix on Windows uses a bundled Python 3.8
           - os: windows-latest
-            python-version: 3.7
+            python-version: 3.8
+          - os: windows-latest
+            python-version: 3.9
     steps:
       - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   tests:
     name: Add-on testing
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       PYTHONIOENCODING: utf-8
       PYTHONPATH: ${{ github.workspace }}/resources/lib
@@ -14,7 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        exclude:
+          # The bundled version of Python in the windows build is 3.8
+          - os: windows-latest
+            python-version: 3.6
+          - os: windows-latest
+            python-version: 3.7
     steps:
       - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
         uses: actions/checkout@v2
@@ -22,10 +29,13 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install dependencies (linux)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install gettext
           sudo pip install coverage --install-option="--install-scripts=/usr/bin"
+      - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run pylint
@@ -33,6 +43,7 @@ jobs:
       - name: Run tox
         run: make check-tox
       - name: Check translations
+        if: matrix.os == 'ubuntu-latest'
         run: make check-translations
       - name: Run unit tests
         run: coverage run -m unittest discover
@@ -45,5 +56,6 @@ jobs:
 #          ADDON_PASSWORD: ${{ secrets.ADDON_PASSWORD }}
 #          ADDON_USERNAME: ${{ secrets.ADDON_USERNAME }}
       - name: Upload code coverage to CodeCov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v1
         continue-on-error: true

--- a/resources/lib/solocoo/epg.py
+++ b/resources/lib/solocoo/epg.py
@@ -97,16 +97,21 @@ class EpgApi:
         if not isinstance(channels, list):
             channels = [channels]
 
+        # Python 2.7 doesn't support .timestamp(), and windows doesn't do '%s', so we need to calculate it ourself
+        epoch = datetime(1970, 1, 1, tzinfo=dateutil.tz.gettz('UTC'))
+
         # Generate dates in UTC format
         if date_from is not None:
             date_from = self._parse_date(date_from)
         else:
             date_from = self._parse_date('today')
+        date_from_posix = str(int((date_from - epoch).total_seconds())) + '000'
 
         if date_to is not None:
             date_to = self._parse_date(date_to)
         else:
             date_to = (date_from + timedelta(days=1))
+        date_to_posix = str(int((date_to - epoch).total_seconds())) + '000'
 
         programs = {}
 
@@ -122,8 +127,8 @@ class EpgApi:
                     'u': self._tokens.device_serial,
                     'a': self._tenant.get('app'),
                     's': '!'.join(channels[i:i + self.EPG_CAPI_CHUNK_SIZE]),  # station id's separated with a !
-                    'f': date_from.strftime("%s") + '000',  # from timestamp
-                    't': date_to.strftime("%s") + '000',  # to timestamp
+                    'f': date_from_posix,  # from timestamp
+                    't': date_to_posix,  # to timestamp
                     # 736763 = BIT_EPG_DETAIL_ID | BIT_EPG_DETAIL_TITLE | BIT_EPG_DETAIL_DESCRIPTION | BIT_EPG_DETAIL_AGE |
                     #          BIT_EPG_DETAIL_CATEGORY | BIT_EPG_DETAIL_START | BIT_EPG_DETAIL_END | BIT_EPG_DETAIL_FLAGS |
                     #          BIT_EPG_DETAIL_COVER | BIT_EPG_DETAIL_SEASON_NO | BIT_EPG_DETAIL_EPISODE_NO |


### PR DESCRIPTION
Fixes the EPG on Windows.

* Windows doesn't support `date_from.strftime("%s")` and Python 2.7 doesn't support `date_from.timestamp()` so we need to calculate it ourself.
* Use correct timestamp, since we were actually using a CET timestamp when we should have used a UTC tiimetsmap.
* Also make sure we run tests on windows in CI.

Fixes #27 