### PR TITLE
Fix iterator error

### DIFF
--- a/resources/lib/solocoo/util.py
+++ b/resources/lib/solocoo/util.py
@@ -213,7 +213,7 @@ def parse_epg_capi(program, tenant):
 
     # Parse credits
     credit_list = []
-    for credit in program.get('credits', []):
+    for credit in program.get('credits') or []:
         if not credit.get('r'):  # Actor
             credit_list.append(Credit(role=Credit.ROLE_ACTOR, person=credit.get('p'), character=credit.get('c')))
         elif credit.get('r') == 1:  # Director


### PR DESCRIPTION
Sometimes the program-data contains `{credits: None}`. 
`program.get('credits', [])` only falls back when the credits key isn't set.

This PR fixes this case by falling back to an empty list.
